### PR TITLE
chore(ci): test against latest nodejs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 script: npm run travis
 language: node_js
 node_js:
-  - 'iojs'
-  - '0.12'
-  - '0.11'
-  - '0.10'
+  - '8'
+  - '10'
+  - '12'
+  - '13'

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "upload-coveralls": "cat coverage/lcov.info | coveralls",
     "lint": "npm run -s lint-js && npm run -s lint-ec",
     "lint-js": "node globstar.js -n --ignore \"coverage/**\" -- eslint \"**/*.js\"",
-    "lint-ec": "node globstar.js -n --ignore \"coverage/**\" -- editorconfig-tools check \"**/*.js\"",
+    "lint-ec": "node globstar.js -n --ignore \"coverage/**\" -- eclint check \"**/*.js\"",
     "clean-cover": "rimraf coverage"
   },
   "dependencies": {
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.2",
-    "editorconfig-tools": "^0.1.1",
+    "eclint": "^2.8.1",
     "eslint": "^0.16.2",
     "ghooks": "^0.2.5",
     "istanbul": "^0.3.7",


### PR DESCRIPTION
- test against node 8, 10, 12, 13
- Use eclint instead of editorconfig-tools. edtorconfig-tools 0.1.1 does not work on node 12. It depends on graceful-fs v3.